### PR TITLE
Cache headers added to /maven endpoint

### DIFF
--- a/src/main/java/io/quarkus/registry/app/admin/AdminApi.java
+++ b/src/main/java/io/quarkus/registry/app/admin/AdminApi.java
@@ -23,6 +23,7 @@ import io.quarkus.registry.app.events.ExtensionCatalogImportEvent;
 import io.quarkus.registry.app.events.ExtensionCompatibilityCreateEvent;
 import io.quarkus.registry.app.events.ExtensionCompatibleDeleteEvent;
 import io.quarkus.registry.app.events.ExtensionCreateEvent;
+import io.quarkus.registry.app.maven.cache.MavenCacheClear;
 import io.quarkus.registry.app.model.ExtensionRelease;
 import io.quarkus.registry.app.model.Platform;
 import io.quarkus.registry.app.model.PlatformRelease;
@@ -125,6 +126,14 @@ public class AdminApi {
                 .orElseThrow(() -> new WebApplicationException(Response.Status.NOT_FOUND));
         ExtensionCompatibleDeleteEvent event = new ExtensionCompatibleDeleteEvent(extensionRelease, quarkusCore);
         adminService.onExtensionCompatibilityDelete(event);
+        return Response.accepted().build();
+    }
+    
+    @DELETE
+    @Path("/v1/maven/cache")
+    @SecurityRequirement(name = "Authentication")
+    @MavenCacheClear
+    public Response clearCache(){
         return Response.accepted().build();
     }
 }

--- a/src/main/java/io/quarkus/registry/app/maven/MavenConfig.java
+++ b/src/main/java/io/quarkus/registry/app/maven/MavenConfig.java
@@ -3,7 +3,6 @@ package io.quarkus.registry.app.maven;
 import javax.enterprise.context.ApplicationScoped;
 
 import io.quarkus.maven.ArtifactCoords;
-import org.apache.maven.artifact.Artifact;
 
 @ApplicationScoped
 public class MavenConfig {

--- a/src/main/java/io/quarkus/registry/app/maven/MavenResource.java
+++ b/src/main/java/io/quarkus/registry/app/maven/MavenResource.java
@@ -13,8 +13,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import io.quarkus.maven.ArtifactCoords;
-import io.quarkus.registry.app.maven.cache.MavenCacheClear;
-import javax.ws.rs.DELETE;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
 
@@ -72,12 +70,5 @@ public class MavenResource {
         }
         log.warnf("Not found: %s", uriInfo.getPath());
         return Response.status(Response.Status.NOT_FOUND).build();
-    }
-
-    @DELETE
-    @Path("/cache")
-    @MavenCacheClear
-    public Response clearCache(){
-        return Response.accepted().build();
     }
 }

--- a/src/main/java/io/quarkus/registry/app/maven/NonPlatformExtensionsContentProvider.java
+++ b/src/main/java/io/quarkus/registry/app/maven/NonPlatformExtensionsContentProvider.java
@@ -2,7 +2,6 @@ package io.quarkus.registry.app.maven;
 
 import java.io.StringWriter;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.HttpHeaders;
@@ -15,7 +14,6 @@ import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.app.DatabaseRegistryClient;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.catalog.json.JsonCatalogMapperHelper;
-import org.apache.maven.artifact.Artifact;
 
 @Singleton
 public class NonPlatformExtensionsContentProvider implements ArtifactContentProvider {

--- a/src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java
+++ b/src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java
@@ -2,7 +2,6 @@ package io.quarkus.registry.app.maven;
 
 import java.io.StringWriter;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.HttpHeaders;
@@ -15,7 +14,6 @@ import io.quarkus.maven.ArtifactCoords;
 import io.quarkus.registry.app.DatabaseRegistryClient;
 import io.quarkus.registry.catalog.PlatformCatalog;
 import io.quarkus.registry.catalog.json.JsonCatalogMapperHelper;
-import org.apache.maven.artifact.Artifact;
 
 /**
  * Lists the available platforms and their recommended versions, indicating which platform is the recommended default for new projects

--- a/src/main/java/io/quarkus/registry/app/maven/PomContentProvider.java
+++ b/src/main/java/io/quarkus/registry/app/maven/PomContentProvider.java
@@ -4,15 +4,14 @@ import java.io.IOException;
 import java.io.StringWriter;
 
 import javax.annotation.Priority;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.spi.Prioritized;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import io.quarkus.maven.ArtifactCoords;
-import org.apache.maven.artifact.Artifact;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Repository;
 import org.apache.maven.model.RepositoryPolicy;
@@ -42,7 +41,9 @@ public class PomContentProvider implements ArtifactContentProvider {
         } else if (ArtifactParser.SUFFIX_SHA1.equals(checksumSuffix)) {
             result = HashUtil.sha1(result);
         }
-        return Response.ok(result).build();
+        return Response.ok(result)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML)
+                .build();
     }
 
     private static String generatePom(ArtifactCoords artifact, UriInfo uriInfo) throws IOException {

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheClearInterceptor.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheClearInterceptor.java
@@ -1,5 +1,6 @@
 package io.quarkus.registry.app.maven.cache;
 
+import javax.annotation.Priority;
 import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
@@ -9,6 +10,7 @@ import javax.interceptor.InvocationContext;
  * Interceptor that fire a event to notify that the cache should be cleared
  */
 @Interceptor
+@Priority(0)
 @MavenCacheClear
 public class MavenCacheClearInterceptor {
     

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
@@ -48,7 +48,7 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
                 if(notModified){
                     containerRequestContext.abortWith(toNotModifiedResponse(mavenResponse));
                 }else {
-                    log.warn("Serving [" + path + "] from cache");
+                    log.debug("Serving [" + path + "] from cache");
                     containerRequestContext.abortWith(toResponse(mavenResponse));
                 }    
             }
@@ -60,7 +60,7 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
         if(isMavenGetRequest(containerRequestContext) && !isCachedResponse(containerResponseContext) && containerResponseContext.getStatus()==200){ 
             String path = containerRequestContext.getUriInfo().getPath();
-            log.warn("Caching [" + path + "]");
+            log.debug("Caching [" + path + "]");
             mavenCache.getCache().put(path, toMavenResponse(containerResponseContext));
         }
     }

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
@@ -1,13 +1,19 @@
 package io.quarkus.registry.app.maven.cache;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -26,36 +32,108 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
     @ConfigProperty(name = "maven.cache.path", defaultValue = "/maven")
     String pathToCache;
     
+    @ConfigProperty(name = "maven.cache.header.cache-control", defaultValue = "no-cache") // Check for etag everytime
+    String headerCacheControl;
+    
     @Override
     public void filter(ContainerRequestContext containerRequestContext) throws IOException {
         if(isMavenGetRequest(containerRequestContext)){
             String path = containerRequestContext.getUriInfo().getPath();
             MavenResponse mavenResponse = mavenCache.getCache().getIfPresent(path);
             if(mavenResponse!=null){
-                log.debug("Serving [" + path + "] from cache");
-                containerRequestContext.abortWith(toResponse(mavenResponse));
+                
+                // Check if we can response with Not Modified
+                boolean notModified = notModified(containerRequestContext, mavenResponse);
+                    
+                if(notModified){
+                    containerRequestContext.abortWith(toNotModifiedResponse(mavenResponse));
+                }else {
+                    log.warn("Serving [" + path + "] from cache");
+                    containerRequestContext.abortWith(toResponse(mavenResponse));
+                }    
             }
+            // Else fall through to the actual endpoint
         }
     }
     
     @Override
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
-        if(isMavenGetRequest(containerRequestContext) && !isCachedResponse(containerResponseContext) && containerResponseContext.getStatus()==200){
+        if(isMavenGetRequest(containerRequestContext) && !isCachedResponse(containerResponseContext) && containerResponseContext.getStatus()==200){ 
             String path = containerRequestContext.getUriInfo().getPath();
-            log.debug("Caching [" + path + "]");
+            log.warn("Caching [" + path + "]");
             mavenCache.getCache().put(path, toMavenResponse(containerResponseContext));
         }
     }
     
+    private boolean notModified(ContainerRequestContext containerRequestContext, MavenResponse cachedResponse){
+        // Here we first check the request header for If-None-Match (etag) or If-Modified-Since (last-modified)
+        
+        // First Check Etag
+        String givenEtag = containerRequestContext.getHeaderString(IF_NONE_MATCH);
+        String cachedEtag = cachedResponse.getHeaders().get(ETAG);
+        if(givenEtag!=null && cachedEtag!=null && givenEtag.equals(cachedEtag)){
+            return true;
+        }
+        
+        // Secondly Check Last Modified    
+        String givenLastModified = containerRequestContext.getHeaderString(IF_MODIFIED_SINCE);
+        String cachedLastModified = cachedResponse.getHeaders().get(LAST_MODIFIED);
+        if(givenLastModified!=null && cachedLastModified!=null && givenLastModified.equals(cachedLastModified)){
+            return true;
+        }
+        
+        return false;
+    }
+    
     private MavenResponse toMavenResponse(ContainerResponseContext containerResponseContext){
         MavenResponse mavenResponse = new MavenResponse(containerResponseContext.getStatus(),containerResponseContext.getEntity());
-        Set<String> headerKeys = containerResponseContext.getHeaders().keySet();
+        
+        // We add some cache related headers here for when using via a CDN etc.
+        // see https://www.keycdn.com/blog/http-cache-headers#no-cache-and-no-store
+
+        // Cache control
+        containerResponseContext.getHeaders().add(CACHE_CONTROL, headerCacheControl);
+        
+        // Etag (to be compared with If-None-Match)
+        // We try and set this based on the actual content. This means that if the content did not change (even if we recreate the cache)
+        // the etag will be the same.
+        EntityTag etag = containerResponseContext.getEntityTag();
+        if(etag==null){
+            // etag - We create a hash from the Response if this is a String, so even if the cache clear, if the content is the same, the etag will also be
+            if(containerResponseContext.getEntityClass().equals(String.class)){
+                String content = (String)containerResponseContext.getEntity();
+                String uuid = UUID.nameUUIDFromBytes(content.getBytes()).toString();
+                containerResponseContext.getHeaders().put(ETAG, List.of(uuid));
+            // etag - Else we just use a UUID, this will change everytime our cache invalidate
+            }else{
+                String randomEtag = UUID.randomUUID().toString();
+                containerResponseContext.getHeaders().put(ETAG, List.of(randomEtag));
+            }
+        }
+        
+        // Last-Modified (to be compared with If-Modified-Since)
+        // For now we set the date when we cached this, but a better way would be to get a date from when this was persisted (changed)
+        LocalDateTime cachedAt = LocalDateTime.now(ZoneOffset.UTC);
+        containerResponseContext.getHeaders().add(LAST_MODIFIED, cachedAt.format(lastModifiedDateFormatter));
+        
+        // Now we should have all the headers we want to cache
+        Set<String> headerKeys = containerResponseContext.getStringHeaders().keySet();
         for(String key : headerKeys){
             mavenResponse.addHeader(key, containerResponseContext.getHeaderString(key));
         }
+        
         return mavenResponse;
     }
 
+    private Response toNotModifiedResponse(MavenResponse mavenResponse){
+        Response.ResponseBuilder responseBuilder = Response.status(NOT_MODIFIED_STATUS);
+        responseBuilder = responseBuilder.header(VIA, VIA_CACHE);
+        for(Map.Entry<String, String> header : mavenResponse.getHeaders().entrySet()){
+            responseBuilder.header(header.getKey(), header.getValue());
+        }
+        return responseBuilder.build();
+    }
+    
     private Response toResponse(MavenResponse mavenResponse){
         Response.ResponseBuilder responseBuilder = Response.status(mavenResponse.getStatus()).entity(mavenResponse.getResponse());
         responseBuilder = responseBuilder.header(VIA, VIA_CACHE);
@@ -77,5 +155,13 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
     private static final String GET = "GET";
     private static final String VIA = "Via";
     private static final String VIA_CACHE = "register.quarkus.io maven-cache";
+    private static final String ETAG = "etag";
+    private static final String CACHE_CONTROL = "cache-control";
+    private static final String LAST_MODIFIED = "last-modified";
+    private static final String IF_NONE_MATCH = "if-none-match";
+    private static final String IF_MODIFIED_SINCE = "if-modified-since";
     
+    private static final int NOT_MODIFIED_STATUS = 304;
+    
+    private static final DateTimeFormatter lastModifiedDateFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss' GMT'");
 }

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
@@ -40,7 +40,7 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
     
     @Override
     public void filter(ContainerRequestContext containerRequestContext, ContainerResponseContext containerResponseContext) throws IOException {
-        if(isMavenGetRequest(containerRequestContext) && !isCachedResponse(containerResponseContext)){
+        if(isMavenGetRequest(containerRequestContext) && !isCachedResponse(containerResponseContext) && containerResponseContext.getStatus()==200){
             String path = containerRequestContext.getUriInfo().getPath();
             log.debug("Caching [" + path + "]");
             mavenCache.getCache().put(path, toMavenResponse(containerResponseContext));

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
@@ -48,7 +48,7 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
     }
     
     private MavenResponse toMavenResponse(ContainerResponseContext containerResponseContext){
-        MavenResponse mavenResponse = new MavenResponse(containerResponseContext.getStatus(),(String)containerResponseContext.getEntity());
+        MavenResponse mavenResponse = new MavenResponse(containerResponseContext.getStatus(),containerResponseContext.getEntity());
         Set<String> headerKeys = containerResponseContext.getHeaders().keySet();
         for(String key : headerKeys){
             mavenResponse.addHeader(key, containerResponseContext.getHeaderString(key));

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenResponse.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenResponse.java
@@ -8,14 +8,14 @@ import java.util.HashMap;
  */
 public class MavenResponse {
     private int status;
-    private String response;
+    private Object response;
     private Map<String,String> headers = new HashMap<>();
     
     public MavenResponse(){
         
     }
     
-    public MavenResponse(int status, String response) {
+    public MavenResponse(int status, Object response) {
         this.status = status;
         this.response = response;
     }
@@ -28,11 +28,11 @@ public class MavenResponse {
         this.status = status;
     }
 
-    public String getResponse() {
+    public Object getResponse() {
         return response;
     }
 
-    public void setResponse(String response) {
+    public void setResponse(Object response) {
         this.response = response;
     }
 

--- a/src/main/java/io/quarkus/registry/app/model/Platform.java
+++ b/src/main/java/io/quarkus/registry/app/model/Platform.java
@@ -15,7 +15,6 @@ import javax.persistence.OrderBy;
 import io.quarkiverse.hibernate.types.json.JsonTypes;
 import org.hibernate.Session;
 import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.SortNatural;
 import org.hibernate.annotations.Type;
 
 @Entity

--- a/src/test/java/io/quarkus/registry/app/maven/ArtifactParserTest.java
+++ b/src/test/java/io/quarkus/registry/app/maven/ArtifactParserTest.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import javax.ws.rs.core.PathSegment;
 
 import io.quarkus.maven.ArtifactCoords;
-import org.apache.maven.artifact.Artifact;
 import org.assertj.core.api.SoftAssertions;
 import org.jboss.resteasy.specimpl.PathSegmentImpl;
 import org.junit.jupiter.api.Disabled;


### PR DESCRIPTION
This PR is mainly to add the cache related headers to the response for `/maven` endpoint.

This is the Etag that is a UUID based on the response content and a last modified based on the cache date.

This also do (separate commits):

- Moved clear cache to admin
- Only cache 200 responses
- Changed content to Object (rather than casting to String)
- Clean up some unused imports
- Added content type header to pom response