### PR TITLE
Added a way to disable the maven cache

### DIFF
--- a/src/main/java/io/quarkus/registry/app/maven/MavenResource.java
+++ b/src/main/java/io/quarkus/registry/app/maven/MavenResource.java
@@ -1,7 +1,5 @@
 package io.quarkus.registry.app.maven;
 
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -10,19 +8,13 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.PathSegment;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import io.quarkus.cache.CacheResult;
 import io.quarkus.maven.ArtifactCoords;
-import io.quarkus.registry.app.CacheNames;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.jboss.logging.Logger;
-import org.sonatype.nexus.repository.metadata.model.RepositoryMetadata;
-import org.sonatype.nexus.repository.metadata.model.io.xpp3.RepositoryMetadataXpp3Writer;
 
 /**
  * Exposes a Maven resource for our tooling

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
@@ -66,9 +66,14 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
             throws IOException {
         if (isMavenGetRequest(containerRequestContext) && !isCachedResponse(containerResponseContext)
                 && containerResponseContext.getStatus() == 200) {
-            String path = containerRequestContext.getUriInfo().getPath();
-            log.debug("Caching [" + path + "]");
-            mavenCache.getCache().put(path, toMavenResponse(containerResponseContext));
+            
+            MavenResponse mavenResponse = toMavenResponse(containerResponseContext);
+            
+            if (enabled.get()) {
+                String path = containerRequestContext.getUriInfo().getPath();
+                log.debug("Caching [" + path + "]");
+                mavenCache.getCache().put(path, mavenResponse);
+            }
         }
     }
 

--- a/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
+++ b/src/main/java/io/quarkus/registry/app/maven/cache/MavenCacheFilter.java
@@ -37,9 +37,12 @@ public class MavenCacheFilter implements ContainerRequestFilter, ContainerRespon
     @ConfigProperty(name = "maven.cache.header.cache-control", defaultValue = "no-cache") // Check for etag everytime
     Instance<String> headerCacheControl;
 
+    @ConfigProperty(name = "maven.cache.enabled", defaultValue = "true")
+    Instance<Boolean> enabled;
+    
     @Override
     public void filter(ContainerRequestContext containerRequestContext) throws IOException {
-        if (isMavenGetRequest(containerRequestContext)) {
+        if (isMavenGetRequest(containerRequestContext) && enabled.get()) {
             String path = containerRequestContext.getUriInfo().getPath();
             MavenResponse mavenResponse = mavenCache.getCache().getIfPresent(path);
             if (mavenResponse != null) {


### PR DESCRIPTION
main currently failing (even before this change) with:

`ERROR] Failures: 
[ERROR]   RepositoryMetadataResourceTest.should_support_repository_proxied_as_nexus_repository:40 1 expectation failed.
Response body doesn't match expectation.
Expected: is "/foo"
  Actual: ## repository-prefixes/2.0
/foo`

Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>