### PR TITLE
Expose endpoint metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
The AppSRE team requires relevant metrics to support SLI monitoring and SLO-based alerting