### PR TITLE
Introduce endpoints to delete an extension (or a specific version)

### DIFF
--- a/src/main/java/io/quarkus/registry/app/admin/AdminService.java
+++ b/src/main/java/io/quarkus/registry/app/admin/AdminService.java
@@ -13,6 +13,7 @@ import io.quarkus.registry.app.events.ExtensionCatalogImportEvent;
 import io.quarkus.registry.app.events.ExtensionCompatibilityCreateEvent;
 import io.quarkus.registry.app.events.ExtensionCompatibleDeleteEvent;
 import io.quarkus.registry.app.events.ExtensionCreateEvent;
+import io.quarkus.registry.app.events.ExtensionDeleteEvent;
 import io.quarkus.registry.app.model.DbState;
 import io.quarkus.registry.app.model.Extension;
 import io.quarkus.registry.app.model.ExtensionRelease;
@@ -75,6 +76,21 @@ public class AdminService {
             DbState.updateUpdatedAt();
         } catch (Exception e) {
             Log.error("Error while inserting extension", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Transactional
+    public void onExtensionDelete(ExtensionDeleteEvent event) {
+        // Non-platform extension
+        try {
+            Extension extension = event.getExtension();
+            // Reattach extension
+            extension = Extension.getEntityManager().merge(extension);
+            extension.delete();
+            DbState.updateUpdatedAt();
+        } catch (Exception e) {
+            Log.error("Error while deleting extension", e);
             throw new IllegalStateException(e);
         }
     }

--- a/src/main/java/io/quarkus/registry/app/admin/AdminService.java
+++ b/src/main/java/io/quarkus/registry/app/admin/AdminService.java
@@ -14,6 +14,7 @@ import io.quarkus.registry.app.events.ExtensionCompatibilityCreateEvent;
 import io.quarkus.registry.app.events.ExtensionCompatibleDeleteEvent;
 import io.quarkus.registry.app.events.ExtensionCreateEvent;
 import io.quarkus.registry.app.events.ExtensionDeleteEvent;
+import io.quarkus.registry.app.events.ExtensionReleaseDeleteEvent;
 import io.quarkus.registry.app.model.DbState;
 import io.quarkus.registry.app.model.Extension;
 import io.quarkus.registry.app.model.ExtensionRelease;
@@ -88,6 +89,21 @@ public class AdminService {
             // Reattach extension
             extension = Extension.getEntityManager().merge(extension);
             extension.delete();
+            DbState.updateUpdatedAt();
+        } catch (Exception e) {
+            Log.error("Error while deleting extension", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Transactional
+    public void onExtensionReleaseDelete(ExtensionReleaseDeleteEvent event) {
+        // Non-platform extension
+        try {
+            ExtensionRelease extensionRelease = event.getExtensionRelease();
+            // Reattach extension
+            extensionRelease = ExtensionRelease.getEntityManager().merge(extensionRelease);
+            extensionRelease.delete();
             DbState.updateUpdatedAt();
         } catch (Exception e) {
             Log.error("Error while deleting extension", e);

--- a/src/main/java/io/quarkus/registry/app/events/ExtensionDeleteEvent.java
+++ b/src/main/java/io/quarkus/registry/app/events/ExtensionDeleteEvent.java
@@ -1,0 +1,16 @@
+package io.quarkus.registry.app.events;
+
+import io.quarkus.registry.app.model.Extension;
+
+public class ExtensionDeleteEvent implements BaseEvent {
+
+    private final Extension extension;
+
+    public ExtensionDeleteEvent(Extension extension) {
+        this.extension = extension;
+    }
+
+    public Extension getExtension() {
+        return extension;
+    }
+}

--- a/src/main/java/io/quarkus/registry/app/events/ExtensionReleaseDeleteEvent.java
+++ b/src/main/java/io/quarkus/registry/app/events/ExtensionReleaseDeleteEvent.java
@@ -1,0 +1,16 @@
+package io.quarkus.registry.app.events;
+
+import io.quarkus.registry.app.model.ExtensionRelease;
+
+public class ExtensionReleaseDeleteEvent implements BaseEvent {
+
+    private final ExtensionRelease extensionRelease;
+
+    public ExtensionReleaseDeleteEvent(ExtensionRelease extensionRelease) {
+        this.extensionRelease = extensionRelease;
+    }
+
+    public ExtensionRelease getExtensionRelease() {
+        return extensionRelease;
+    }
+}


### PR DESCRIPTION
This change allows an authenticated request to delete extensions or extension versions. This is useful in cases where the extension is deleted from the extension catalog.