### PR TITLE
Queries for non-platform extensions will at least match the requested quarkus core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <maven.buildNumber.shortRevisionLength>7</maven.buildNumber.shortRevisionLength>
     <maven.buildNumber.getRevisionOnlyOnce>true</maven.buildNumber.getRevisionOnlyOnce>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
-    <quarkus.version>2.5.1.Final</quarkus.version>
+    <quarkus.version>2.5.2.Final</quarkus.version>
     <quarkus-hibernate-types.version>0.2.0</quarkus-hibernate-types.version>
     <revision>999-SNAPSHOT</revision>
   </properties>

--- a/src/main/java/db/migration/V7__Fix_Quarkus_Core.java
+++ b/src/main/java/db/migration/V7__Fix_Quarkus_Core.java
@@ -1,0 +1,55 @@
+package db.migration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.maven.ArtifactCoords;
+import io.quarkus.registry.catalog.json.JsonCatalogMapperHelper;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+import static io.quarkus.registry.catalog.Extension.MD_BUILT_WITH_QUARKUS_CORE;
+
+/**
+ * Quarkus core version column in ExtensionRelease table was always being set to 0.0.0.0
+ * This migration will read from the JSON metadata and update the value accordingly
+ */
+public class V7__Fix_Quarkus_Core extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Connection connection = context.getConnection();
+        // Get existing Quarkus Core Versions
+        try (PreparedStatement stmt = connection.prepareStatement(
+                "SELECT * FROM extension_release WHERE quarkus_core_version = '0.0.0' and metadata is not null",
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_UPDATABLE);
+                ResultSet resultSet = stmt.executeQuery()) {
+            while (resultSet.next()) {
+                String metadata = resultSet.getString("metadata");
+                String quarkusCoreVersion = extractQuarkusCore(metadata);
+                resultSet.updateString("quarkus_core_version", quarkusCoreVersion);
+                resultSet.updateRow();
+            }
+        }
+    }
+
+    private String extractQuarkusCore(String json) throws Exception {
+        JsonNode jsonNode = JsonCatalogMapperHelper.mapper().readTree(json);
+        String quarkusCore = jsonNode.path(MD_BUILT_WITH_QUARKUS_CORE).textValue();
+        // Some extensions were published using the full GAV
+        if (quarkusCore == null) {
+            // Cannot determine Quarkus version
+            quarkusCore = "0.0.0";
+        } else if (quarkusCore.contains(":")) {
+            try {
+                quarkusCore = ArtifactCoords.fromString(quarkusCore).getVersion();
+            } catch (IllegalArgumentException iae) {
+                // ignore
+            }
+        }
+        return quarkusCore;
+    }
+}

--- a/src/main/java/db/migration/V7__Update_Quarkus_Core_Version_Sortable.java
+++ b/src/main/java/db/migration/V7__Update_Quarkus_Core_Version_Sortable.java
@@ -1,0 +1,47 @@
+package db.migration;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.logging.Log;
+import io.quarkus.registry.app.util.Version;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+
+/**
+ * Update the quarkus_core_version_sortable column with the quarkus_core_version data
+ */
+public class V7__Update_Quarkus_Core_Version_Sortable extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Map<String, String> transformedVersions = new HashMap<>();
+        Connection connection = context.getConnection();
+        // Get existing Quarkus Core Versions
+        try (PreparedStatement stmt = connection.prepareStatement(
+                "SELECT DISTINCT QUARKUS_CORE_VERSION FROM extension_release");
+                ResultSet resultSet = stmt.executeQuery()) {
+            while (resultSet.next()) {
+                String quarkusCoreVersion = resultSet.getString(1);
+                transformedVersions.put(quarkusCoreVersion, Version.toSortable(quarkusCoreVersion));
+            }
+        }
+        if (transformedVersions.size() > 0) {
+            // Execute Updates
+            try (PreparedStatement stmt = connection.prepareStatement(
+                    "UPDATE extension_release set quarkus_core_version_sortable = ? where quarkus_core_version = ?");) {
+                for (Map.Entry<String, String> entry : transformedVersions.entrySet()) {
+                    String original = entry.getKey();
+                    String sortable = entry.getValue();
+                    stmt.setString(1, sortable);
+                    stmt.setString(2, original);
+                    int rows = stmt.executeUpdate();
+                    Log.infof("%s rows updated from %s to %s%n", rows, original, sortable);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/db/migration/V8__Update_Quarkus_Core_Version_Sortable.java
+++ b/src/main/java/db/migration/V8__Update_Quarkus_Core_Version_Sortable.java
@@ -14,7 +14,7 @@ import org.flywaydb.core.api.migration.Context;
 /**
  * Update the quarkus_core_version_sortable column with the quarkus_core_version data
  */
-public class V7__Update_Quarkus_Core_Version_Sortable extends BaseJavaMigration {
+public class V8__Update_Quarkus_Core_Version_Sortable extends BaseJavaMigration {
 
     @Override
     public void migrate(Context context) throws Exception {
@@ -39,7 +39,7 @@ public class V7__Update_Quarkus_Core_Version_Sortable extends BaseJavaMigration 
                     stmt.setString(1, sortable);
                     stmt.setString(2, original);
                     int rows = stmt.executeUpdate();
-                    Log.infof("%s rows updated from %s to %s%n", rows, original, sortable);
+                    Log.debugf("%s rows updated from %s to %s%n", rows, original, sortable);
                 }
             }
         }

--- a/src/main/java/io/quarkus/registry/app/admin/AdminService.java
+++ b/src/main/java/io/quarkus/registry/app/admin/AdminService.java
@@ -26,6 +26,8 @@ import io.quarkus.registry.app.model.PlatformStream;
 import io.quarkus.registry.catalog.ExtensionCatalog;
 import io.quarkus.registry.util.PlatformArtifacts;
 
+import static io.quarkus.registry.catalog.Extension.MD_BUILT_WITH_QUARKUS_CORE;
+
 /**
  * Administrative operations on the database
  */
@@ -139,18 +141,17 @@ public class AdminService {
                     ExtensionRelease newExtensionRelease = new ExtensionRelease();
                     newExtensionRelease.version = version;
                     newExtensionRelease.extension = extension;
-                    String quarkusCore = (String) ext.getMetadata()
-                            .get(io.quarkus.registry.catalog.Extension.MD_BUILT_WITH_QUARKUS_CORE);
+                    String quarkusCore = (String) ext.getMetadata().get(MD_BUILT_WITH_QUARKUS_CORE);
                     // Some extensions were published using the full GAV
-                    if (quarkusCore != null && quarkusCore.contains(":")) {
+                    if (quarkusCore == null) {
+                        // Cannot determine Quarkus version
+                        quarkusCore = "0.0.0";
+                    } else if (quarkusCore.contains(":")) {
                         try {
                             quarkusCore = ArtifactCoords.fromString(quarkusCore).getVersion();
                         } catch (IllegalArgumentException iae) {
                             // ignore
                         }
-                    } else {
-                        // Cannot determine Quarkus version
-                        quarkusCore = "0.0.0";
                     }
                     newExtensionRelease.quarkusCoreVersion = quarkusCore;
                     // Many-to-many

--- a/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
@@ -23,11 +23,11 @@ import org.hibernate.annotations.Type;
 @Entity
 @NamedQuery(name = "ExtensionRelease.findNonPlatformExtensions", query = "from ExtensionRelease ext " +
         "where ext.platforms is empty " +
-        "and ext.quarkusCoreVersionSortable >= :quarkusCore " +
+        "and ext.quarkusCoreVersionSortable <= :quarkusCore " +
         "and (ext.versionSortable) = (" +
         "    select max(ext2.versionSortable) from ExtensionRelease ext2" +
         "    where ext2.extension = ext.extension " +
-        "    and ext2.quarkusCoreVersionSortable >= :quarkusCore" +
+        "    and ext2.quarkusCoreVersionSortable <= :quarkusCore" +
         ") ")
 public class ExtensionRelease extends BaseEntity {
 

--- a/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
@@ -23,10 +23,12 @@ import org.hibernate.annotations.Type;
 @Entity
 @NamedQuery(name = "ExtensionRelease.findNonPlatformExtensions", query = "from ExtensionRelease ext " +
         "where ext.platforms is empty " +
+        "and ext.quarkusCoreVersionSortable >= :quarkusCore " +
         "and (ext.versionSortable) = (" +
         "    select max(ext2.versionSortable) from ExtensionRelease ext2" +
-        "    where ext2.extension = ext.extension" +
-        ")")
+        "    where ext2.extension = ext.extension " +
+        "    and ext2.quarkusCoreVersionSortable >= :quarkusCore" +
+        ") ")
 public class ExtensionRelease extends BaseEntity {
 
     @NaturalId
@@ -50,7 +52,10 @@ public class ExtensionRelease extends BaseEntity {
     @Column(nullable = false)
     public String quarkusCoreVersion;
 
-    @OneToMany(mappedBy = "extensionRelease", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+    @Column(nullable = false)
+    public String quarkusCoreVersionSortable;
+
+    @OneToMany(mappedBy = "extensionRelease", cascade = { CascadeType.PERSIST, CascadeType.REMOVE }, orphanRemoval = true)
     public List<PlatformExtension> platforms = new ArrayList<>();
 
     /**
@@ -59,6 +64,7 @@ public class ExtensionRelease extends BaseEntity {
     @PrePersist
     void updateSemVer() {
         this.versionSortable = Version.toSortable(version);
+        this.quarkusCoreVersionSortable = Version.toSortable(quarkusCoreVersion);
     }
 
     @Override
@@ -93,6 +99,7 @@ public class ExtensionRelease extends BaseEntity {
 
     public static List<ExtensionRelease> findNonPlatformExtensions(String quarkusCore) {
         return getEntityManager().createNamedQuery("ExtensionRelease.findNonPlatformExtensions", ExtensionRelease.class)
+                .setParameter("quarkusCore", Version.toSortable(quarkusCore))
                 .getResultList();
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,9 +4,13 @@ quarkus.application.version=${buildNumber}
 quarkus.hibernate-orm.physical-naming-strategy=io.quarkiverse.hibernate.types.util.CamelCaseToSnakeCaseNamingStrategy
 quarkus.datasource.health.enabled=false
 %dev.quarkus.hibernate-orm.log.sql=true
+#%test.quarkus.hibernate-orm.log.sql=true
 
-#%dev.quarkus.hibernate-orm.database.generation=update
-#quarkus.hibernate-orm.database.generation=drop-and-create
+# Uncomment the following if you have a local database running
+#quarkus.datasource.db-kind=postgresql
+#quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres
+#quarkus.datasource.username=quarkus_test
+#quarkus.datasource.password=quarkus_test
 
 quarkus.flyway.migrate-at-start=true
 

--- a/src/main/resources/db/migration/V1__Create_schema.sql
+++ b/src/main/resources/db/migration/V1__Create_schema.sql
@@ -100,7 +100,6 @@ create table platform_release
     version varchar not null,
     version_sortable varchar not null,
     quarkus_core_version varchar not null,
-    pinned bool default false,
     upstream_quarkus_core_version varchar,
     platform_id bigint
         constraint platform_fkey

--- a/src/main/resources/db/migration/V6__Introduce_quarkus_core_version_sortable.sql
+++ b/src/main/resources/db/migration/V6__Introduce_quarkus_core_version_sortable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE extension_release
+    ADD COLUMN IF NOT EXISTS quarkus_core_version_sortable varchar not null default '0';

--- a/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
+++ b/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
@@ -1,26 +1,37 @@
 package io.quarkus.registry.app;
 
+import java.net.HttpURLConnection;
+
 import javax.transaction.Transactional;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import io.quarkus.registry.app.model.Extension;
+import io.quarkus.registry.app.model.ExtensionRelease;
 import io.quarkus.registry.app.model.Platform;
+import io.quarkus.registry.app.model.PlatformExtension;
 import io.quarkus.registry.app.model.PlatformRelease;
 import io.quarkus.registry.app.model.PlatformStream;
 import io.quarkus.test.junit.QuarkusTest;
+import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
 class DatabaseRegistryClientTest {
 
-    @BeforeAll
+    @BeforeEach
     @Transactional
-    static void setUp() {
+    void setUp() {
+        cleanUpDatabase();
         {
             Platform platform = Platform.findByKey("io.quarkus.platform").get();
             PlatformStream stream20 = new PlatformStream();
@@ -50,6 +61,27 @@ class DatabaseRegistryClientTest {
             release210CR1.version = "2.1.0.CR1";
             release210CR1.quarkusCoreVersion = release210CR1.version;
             release210CR1.persistAndFlush();
+
+            Extension extension = new Extension();
+            extension.name = "Foo";
+            extension.description = "A Foo Extension";
+            extension.groupId = "foo.bar";
+            extension.artifactId = "foo-extension";
+            extension.persist();
+            {
+                ExtensionRelease extensionRelease = new ExtensionRelease();
+                extensionRelease.extension = extension;
+                extensionRelease.version = "1.0.0";
+                extensionRelease.quarkusCoreVersion = "2.0.0.Final";
+                extensionRelease.persist();
+            }
+            {
+                ExtensionRelease extensionRelease = new ExtensionRelease();
+                extensionRelease.extension = extension;
+                extensionRelease.version = "1.1.0";
+                extensionRelease.quarkusCoreVersion = "2.1.0.Final";
+                extensionRelease.persist();
+            }
         }
     }
 
@@ -58,7 +90,7 @@ class DatabaseRegistryClientTest {
         given()
                 .get("/client/platforms?v=1.1.0")
                 .then()
-                .statusCode(Response.Status.NO_CONTENT.getStatusCode());
+                .statusCode(HttpURLConnection.HTTP_NO_CONTENT);
     }
 
     @Test
@@ -67,7 +99,7 @@ class DatabaseRegistryClientTest {
                 .accept("application/json;custom=aaaaaaaaaaaaaaaaaa;charset=utf-7")
                 .get("/client/platforms")
                 .then()
-                .statusCode(Response.Status.OK.getStatusCode())
+                .statusCode(HttpURLConnection.HTTP_OK)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     }
 
@@ -77,12 +109,24 @@ class DatabaseRegistryClientTest {
                 .accept(MediaType.APPLICATION_XML)
                 .get("/client/platforms")
                 .then()
-                .statusCode(Response.Status.NOT_ACCEPTABLE.getStatusCode());
+                .statusCode(HttpURLConnection.HTTP_NOT_ACCEPTABLE);
     }
 
-    @AfterAll
+    @Test
+    void should_return_only_extensions_matching_at_least_the_requested_quarkus_core() {
+        given()
+                .get("/client/non-platform-extensions?v=2.0.0.Final")
+                .then()
+                .statusCode(HttpURLConnection.HTTP_OK)
+                .body("extensions[0].artifact", is("foo.bar:foo-extension::jar:1.1.0"));
+    }
+
+    @AfterEach
     @Transactional
-    static void tearDown() {
+    void cleanUpDatabase() {
+        PlatformExtension.deleteAll();
+        ExtensionRelease.deleteAll();
+        Extension.deleteAll();
         PlatformRelease.deleteAll();
         PlatformStream.deleteAll();
     }

--- a/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
+++ b/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
@@ -118,7 +118,7 @@ class DatabaseRegistryClientTest {
                 .get("/client/non-platform-extensions?v=2.0.0.Final")
                 .then()
                 .statusCode(HttpURLConnection.HTTP_OK)
-                .body("extensions[0].artifact", is("foo.bar:foo-extension::jar:1.1.0"));
+                .body("extensions[0].artifact", is("foo.bar:foo-extension::jar:1.0.0"));
     }
 
     @AfterEach

--- a/src/test/java/io/quarkus/registry/app/admin/AdminApiTest.java
+++ b/src/test/java/io/quarkus/registry/app/admin/AdminApiTest.java
@@ -33,6 +33,8 @@ class AdminApiTest {
     @BeforeEach
     @Transactional
     void setUp() {
+        // Make sure database is cleaned before inserting new data
+        cleanUpDatabase();
         {
             Extension extension = new Extension();
             extension.name = "Foo";
@@ -104,7 +106,6 @@ class AdminApiTest {
             extensionReleaseToBeDeleted2.quarkusCoreVersion = "2.0.0.Final";
             extensionReleaseToBeDeleted2.persistAndFlush();
         }
-
     }
 
     @Test
@@ -136,6 +137,7 @@ class AdminApiTest {
         StringWriter sw = new StringWriter();
         JsonCatalogMapperHelper.serialize(jsonExtension, sw);
 
+        // Update extension
         given()
                 .body(sw.toString())
                 .header("Token", "test")
@@ -257,7 +259,7 @@ class AdminApiTest {
 
     @AfterEach
     @Transactional
-    void tearDown() {
+    void cleanUpDatabase() {
         PlatformExtension.deleteAll();
         ExtensionRelease.deleteAll();
         Extension.deleteAll();


### PR DESCRIPTION
- Bumps to Quarkus 2.5.2.Final
- Introduces a fix for the quarkus_core_version column being always '0.0.0'

Fixes #55