### PR TITLE
Introduce `/client/platforms/all`

### DIFF
--- a/src/main/java/io/quarkus/registry/app/maven/NonPlatformExtensionsContentProvider.java
+++ b/src/main/java/io/quarkus/registry/app/maven/NonPlatformExtensionsContentProvider.java
@@ -36,7 +36,7 @@ public class NonPlatformExtensionsContentProvider implements ArtifactContentProv
     @Override
     public Response provide(ArtifactCoords artifact, UriInfo uriInfo) throws Exception {
         String quarkusVersion = artifact.getClassifier();
-        ExtensionCatalog catalog = registryClient.resolveNonPlatformExtensions(quarkusVersion);
+        ExtensionCatalog catalog = registryClient.resolveNonPlatformExtensionsCatalog(quarkusVersion);
 
         StringWriter sw = new StringWriter();
         CatalogMapperHelper.serialize(objectMapper, catalog, sw);

--- a/src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java
+++ b/src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java
@@ -40,7 +40,7 @@ public class PlatformsContentProvider implements ArtifactContentProvider {
     @Override
     public Response provide(ArtifactCoords artifact, UriInfo uriInfo) throws Exception {
         var quarkusVersion = artifact.getClassifier();
-        PlatformCatalog platformCatalog = registryClient.resolvePlatforms(quarkusVersion);
+        PlatformCatalog platformCatalog = registryClient.resolveCurrentPlatformsCatalog(quarkusVersion);
         if (platformCatalog == null || platformCatalog.getPlatforms().isEmpty()) {
             return Response.status(Response.Status.NO_CONTENT)
                     .header("X-Reason", "No platforms found")

--- a/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
+++ b/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
@@ -2,6 +2,7 @@ package io.quarkus.registry.app;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 import java.net.HttpURLConnection;
 
@@ -21,6 +22,7 @@ import io.quarkus.registry.app.model.PlatformExtension;
 import io.quarkus.registry.app.model.PlatformRelease;
 import io.quarkus.registry.app.model.PlatformStream;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
 
 @QuarkusTest
 class DatabaseRegistryClientTest {
@@ -122,6 +124,18 @@ class DatabaseRegistryClientTest {
                 .then()
                 .statusCode(HttpURLConnection.HTTP_OK)
                 .body("extensions[0].artifact", is("foo.bar:foo-extension::jar:1.1.0"));
+    }
+
+    @Test
+    void should_return_all_platforms_with_current_stream_id() {
+        given()
+                .get("/client/platforms/all")
+                .then()
+                .statusCode(HttpURLConnection.HTTP_OK)
+                .contentType(ContentType.JSON)
+                .body("platforms", hasSize(1),
+                        "platforms[0].streams", hasSize(2),
+                        "platforms[0].current-stream-id", is("2.0"));
     }
 
     @AfterEach


### PR DESCRIPTION
This introduces a new endpoint returning all streams available per platform in a PlatformCatalog format

Fixes #67