### PR TITLE
Introduce unlisted streams

### DIFF
--- a/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
+++ b/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
@@ -48,7 +48,7 @@ public class DatabaseRegistryClient {
     @Produces(MediaType.APPLICATION_JSON)
     public PlatformCatalog resolveAllPlatforms() {
         List<PlatformRelease> platformReleases = PlatformRelease.findAll().list();
-        return toPlatformCatalog(platformReleases);
+        return toPlatformCatalog(platformReleases, true);
     }
 
     @GET
@@ -62,7 +62,7 @@ public class DatabaseRegistryClient {
         if (platformReleases.isEmpty()) {
             return null;
         }
-        return toPlatformCatalog(platformReleases);
+        return toPlatformCatalog(platformReleases, false);
     }
 
     @GET
@@ -114,7 +114,7 @@ public class DatabaseRegistryClient {
         return catalog.build();
     }
 
-    private PlatformCatalog toPlatformCatalog(List<PlatformRelease> platformReleases) {
+    private PlatformCatalog toPlatformCatalog(List<PlatformRelease> platformReleases, boolean all) {
         PlatformCatalog.Mutable catalog = PlatformCatalog.builder();
         platformReleases.sort((o1, o2) -> Version.QUALIFIER_REVERSED_COMPARATOR.compare(o1.version, o2.version));
         for (PlatformRelease platformRelease : platformReleases) {
@@ -129,7 +129,11 @@ public class DatabaseRegistryClient {
             io.quarkus.registry.catalog.Platform.Mutable thisClientPlatform;
             if (clientPlatform == null) {
                 thisClientPlatform = toClientPlatform(platform);
-                thisClientPlatform.getMetadata().put("current-stream-id", stream.getId());
+                Map<String, Object> platformMetadata = thisClientPlatform.getMetadata();
+                platformMetadata.put("current-stream-id", stream.getId());
+                if (all) {
+                    platformMetadata.put("unlisted", platformStream.unlisted);
+                }
             } else {
                 thisClientPlatform = clientPlatform.mutable();
             }

--- a/src/main/java/io/quarkus/registry/app/model/PlatformRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/PlatformRelease.java
@@ -33,11 +33,13 @@ import io.quarkus.registry.app.util.Version;
                 "   and (pr.platformStream, pr.versionSortable) in (" +
                 "    select pr2.platformStream, max(pr2.versionSortable) from PlatformRelease pr2" +
                 "    where pr2.quarkusCoreVersion = ?1 " +
+                "    and pr2.platformStream.unlisted = false " +
                 "    group by pr2.platformStream" +
                 "  ) order by pr.versionSortable desc, pr.platformStream.platform.isDefault desc"),
         @NamedQuery(name = "PlatformRelease.findLatest", query = "from PlatformRelease pr " +
                 "where (pr.platformStream, pr.versionSortable) in (" +
                 "    select pr2.platformStream, max(pr2.versionSortable) from PlatformRelease pr2" +
+                "    where pr2.platformStream.unlisted = false " +
                 "    group by pr2.platformStream" +
                 ") order by pr.versionSortable desc, pr.platformStream.platform.isDefault desc")
 })

--- a/src/main/java/io/quarkus/registry/app/model/PlatformStream.java
+++ b/src/main/java/io/quarkus/registry/app/model/PlatformStream.java
@@ -40,6 +40,9 @@ public class PlatformStream extends BaseEntity {
     @Column
     public String name;
 
+    @Column
+    public boolean unlisted;
+
     @Type(type = JsonTypes.JSON_BIN)
     @Column(columnDefinition = "json")
     public Map<String, Object> metadata;

--- a/src/main/resources/db/migration/V9__Introduce_unlisted_streams.sql
+++ b/src/main/resources/db/migration/V9__Introduce_unlisted_streams.sql
@@ -1,0 +1,1 @@
+ALTER TABLE platform_stream ADD COLUMN IF NOT EXISTS unlisted bool DEFAULT false


### PR DESCRIPTION
This introduces an `unlisted` column (default: false) in the `platform_stream` table along with a new admin endpoint to change its value and uses it in the queries. 

Fixes #66