### PR TITLE
Add new endpoint to return all known extensions

### DIFF
--- a/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
+++ b/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -127,20 +126,9 @@ public class DatabaseRegistryClient {
     @Operation(summary = "List all extensions. When an extension has multiple releases, only the most recent will be listed.")
     public ExtensionCatalog resolveAllExtensionsCatalog() {
         final ExtensionCatalog.Mutable catalog = ExtensionCatalog.builder();
-        List<ExtensionRelease> allExtensionReleases = ExtensionRelease.listAll();
+        List<ExtensionRelease> allExtensionReleases = ExtensionRelease.findLatestExtensions();
 
-        // We only want the most recent release for each extension, to avoid returning the whole db on each query
-        Map<String, List<ExtensionRelease>> releasesGroupedByExtension = allExtensionReleases.stream()
-                .collect(Collectors.groupingBy(r -> r.extension.groupId + ":" + r.extension.artifactId));
-        Set<Map.Entry<String, List<ExtensionRelease>>> entries = releasesGroupedByExtension.entrySet();
-
-        // Now sort the lists of extension releases, so we can just pick off the first one
-        entries.forEach(es -> es.getValue().sort((er1, er2) -> er2.versionSortable.compareTo(er1.versionSortable)));
-        // We know every extension has at least one release, because that's why it made it into our map
-        List<ExtensionRelease> mostRecentReleases = entries.stream().map(es -> es.getValue().get(0))
-                .toList();
-
-        mostRecentReleases.stream().map(this::toClientExtension).forEach(catalog::addExtension);
+        allExtensionReleases.stream().map(this::toClientExtension).forEach(catalog::addExtension);
 
         // Add all categories
         List<Category> categories = Category.listAll();

--- a/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
+++ b/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
@@ -214,7 +214,7 @@ public class DatabaseRegistryClient {
                                             platformExtension.platformRelease.version)
                                     .toGACTVString())
                             .setBom(ArtifactCoords.pom(platformExtension.platformRelease.platformStream.platform.platformKey,
-                                    QUARKUS_BOM + "-quarkus-platform-descriptor",
+                                    QUARKUS_BOM,
                                     platformExtension.platformRelease.version))
                             .setMetadata(platformExtension.platformRelease.metadata)
                             .setQuarkusCoreVersion(platformExtension.platformRelease.quarkusCoreVersion)

--- a/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
+++ b/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
@@ -82,7 +82,7 @@ public class DatabaseRegistryClient {
     public ExtensionCatalog resolveNonPlatformExtensionsCatalog(
             @NotNull(message = "The Quarkus version (v) is missing") @QueryParam("v") String quarkusVersion) {
         Version.validateVersion(quarkusVersion);
-        String id = getNonPlatformCoords(quarkusVersion);
+        String id = mavenConfig.getNonPlatformExtensionCoords(quarkusVersion);
 
         final ExtensionCatalog.Mutable catalog = ExtensionCatalog.builder();
         catalog.setId(id);
@@ -193,7 +193,7 @@ public class DatabaseRegistryClient {
 
         if (extensionRelease.platforms.isEmpty()) {
             // Non-platform case
-            String id = getNonPlatformCoords(extensionRelease.quarkusCoreVersion);
+            String id = mavenConfig.getNonPlatformExtensionCoords(extensionRelease.quarkusCoreVersion);
             extensionOrigins = List.of(ExtensionCatalog.builder().setId(id)
                     .setQuarkusCoreVersion(extensionRelease.quarkusCoreVersion)
                     .setPlatform(false)
@@ -279,16 +279,6 @@ public class DatabaseRegistryClient {
                 .setMetadata(platformRelease.metadata)
                 .setUpstreamQuarkusCoreVersion(platformRelease.upstreamQuarkusCoreVersion)
                 .setQuarkusCoreVersion(platformRelease.quarkusCoreVersion);
-    }
-
-    private String getNonPlatformCoords(String quarkusVersion) {
-        ArtifactCoords nonPlatformExtensionCoords = mavenConfig.getNonPlatformExtensionCoords();
-        String id = ArtifactCoords.of(nonPlatformExtensionCoords.getGroupId(),
-                nonPlatformExtensionCoords.getArtifactId(),
-                quarkusVersion,
-                nonPlatformExtensionCoords.getType(),
-                nonPlatformExtensionCoords.getVersion()).toString();
-        return id;
     }
 
     private enum CoreCompatibility {

--- a/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
+++ b/src/main/java/io/quarkus/registry/app/DatabaseRegistryClient.java
@@ -22,6 +22,7 @@ import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 
 import io.quarkus.maven.dependency.ArtifactCoords;
 import io.quarkus.panache.common.Sort;
+import io.quarkus.registry.Constants;
 import io.quarkus.registry.app.maven.MavenConfig;
 import io.quarkus.registry.app.model.Category;
 import io.quarkus.registry.app.model.ExtensionRelease;
@@ -43,6 +44,9 @@ import io.quarkus.registry.catalog.PlatformReleaseVersion;
 @Path("/client")
 @Tag(name = "Client", description = "Client related services")
 public class DatabaseRegistryClient {
+
+    private static final String IO_QUARKUS_PLATFORM = "io.quarkus.platform";
+    private static final String QUARKUS_BOM = "quarkus-bom";
 
     @Inject
     MavenConfig mavenConfig;
@@ -78,16 +82,11 @@ public class DatabaseRegistryClient {
     public ExtensionCatalog resolveNonPlatformExtensionsCatalog(
             @NotNull(message = "The Quarkus version (v) is missing") @QueryParam("v") String quarkusVersion) {
         Version.validateVersion(quarkusVersion);
-        ArtifactCoords nonPlatformExtensionCoords = mavenConfig.getNonPlatformExtensionCoords();
-        String id = ArtifactCoords.of(nonPlatformExtensionCoords.getGroupId(),
-                nonPlatformExtensionCoords.getArtifactId(),
-                quarkusVersion,
-                nonPlatformExtensionCoords.getType(),
-                nonPlatformExtensionCoords.getVersion()).toString();
+        String id = getNonPlatformCoords(quarkusVersion);
 
         final ExtensionCatalog.Mutable catalog = ExtensionCatalog.builder();
         catalog.setId(id);
-        catalog.setBom(ArtifactCoords.pom("io.quarkus.platform", "quarkus-bom", quarkusVersion));
+        catalog.setBom(ArtifactCoords.pom(IO_QUARKUS_PLATFORM, QUARKUS_BOM, quarkusVersion));
         catalog.setQuarkusCoreVersion(quarkusVersion);
         List<ExtensionRelease> nonPlatformExtensions = ExtensionRelease.findNonPlatformExtensions(quarkusVersion);
         Map<Long, Boolean> compatibleMap = ExtensionReleaseCompatibility.findCompatibleMap(quarkusVersion);
@@ -115,6 +114,22 @@ public class DatabaseRegistryClient {
             extension.getMetadata().put("quarkus-core-compatibility", CoreCompatibility.parse(compatibility));
             catalog.addExtension(extension.build());
         }
+        // Add all categories
+        List<Category> categories = Category.listAll();
+        categories.stream().map(this::toClientCategory).forEach(catalog::addCategory);
+        return catalog.build();
+    }
+
+    @GET
+    @Path("/extensions/all")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "List all extensions. When an extension has multiple releases, they will all be listed.")
+    public ExtensionCatalog resolveAllExtensionsCatalog() {
+        final ExtensionCatalog.Mutable catalog = ExtensionCatalog.builder();
+        List<ExtensionRelease> allExtensions = ExtensionRelease.listAll();
+
+        allExtensions.stream().map(this::toClientExtension).forEach(catalog::addExtension);
+
         // Add all categories
         List<Category> categories = Category.listAll();
         categories.stream().map(this::toClientCategory).forEach(catalog::addCategory);
@@ -173,14 +188,63 @@ public class DatabaseRegistryClient {
         return catalog.build();
     }
 
+    private List<ExtensionOrigin> toExtensionOrigins(ExtensionRelease extensionRelease) {
+        final List<ExtensionOrigin> extensionOrigins;
+
+        if (extensionRelease.platforms.isEmpty()) {
+            // Non-platform case
+            String id = getNonPlatformCoords(extensionRelease.quarkusCoreVersion);
+            extensionOrigins = List.of(ExtensionCatalog.builder().setId(id)
+                    .setQuarkusCoreVersion(extensionRelease.quarkusCoreVersion)
+                    .setPlatform(false)
+                    .build());
+        } else {
+
+            // Platform case
+            extensionOrigins = extensionRelease.platforms.stream()
+                    .map((platformExtension) -> (ExtensionOrigin) ExtensionCatalog.builder()
+                            // it should be <platform-key>:<member-bom-artifactId>-quarkus-platform-descriptor:<quarkus-version>:json:<quarkus-version>
+                            // We can get all member boms associated with this release, but not the particular one this extension came from
+                            // For the moment, we assume the member bom is quarkus-core since we don't have information to make a better choise
+                            .setId(ArtifactCoords
+                                    .of(platformExtension.platformRelease.platformStream.platform.platformKey,
+                                            QUARKUS_BOM + "-quarkus-platform-descriptor",
+                                            platformExtension.platformRelease.version,
+                                            Constants.JSON,
+                                            platformExtension.platformRelease.version)
+                                    .toGACTVString())
+                            .setBom(ArtifactCoords.pom(platformExtension.platformRelease.platformStream.platform.platformKey,
+                                    QUARKUS_BOM + "-quarkus-platform-descriptor",
+                                    platformExtension.platformRelease.version))
+                            .setMetadata(platformExtension.platformRelease.metadata)
+                            .setQuarkusCoreVersion(platformExtension.platformRelease.quarkusCoreVersion)
+                            .setPlatform(true).build())
+                    .toList();
+        }
+
+        return extensionOrigins;
+    }
+
     private Extension.Mutable toClientExtension(ExtensionRelease extensionRelease, ExtensionOrigin extensionOrigin) {
+        return toClientExtensionNoOrigin(extensionRelease)
+                .setOrigins(Collections.singletonList(extensionOrigin));
+    }
+
+    private Extension.Mutable toClientExtension(ExtensionRelease extensionRelease) {
+
+        List<ExtensionOrigin> extensionOrigins = toExtensionOrigins(extensionRelease);
+
+        return toClientExtensionNoOrigin(extensionRelease)
+                .setOrigins(extensionOrigins);
+    }
+
+    private Extension.Mutable toClientExtensionNoOrigin(ExtensionRelease extensionRelease) {
         return Extension.builder()
                 .setGroupId(extensionRelease.extension.groupId)
                 .setArtifactId(extensionRelease.extension.artifactId)
                 .setVersion(extensionRelease.version)
                 .setName(extensionRelease.extension.name)
                 .setDescription(extensionRelease.extension.description)
-                .setOrigins(Collections.singletonList(extensionOrigin))
                 .setMetadata(extensionRelease.metadata);
     }
 
@@ -215,6 +279,16 @@ public class DatabaseRegistryClient {
                 .setMetadata(platformRelease.metadata)
                 .setUpstreamQuarkusCoreVersion(platformRelease.upstreamQuarkusCoreVersion)
                 .setQuarkusCoreVersion(platformRelease.quarkusCoreVersion);
+    }
+
+    private String getNonPlatformCoords(String quarkusVersion) {
+        ArtifactCoords nonPlatformExtensionCoords = mavenConfig.getNonPlatformExtensionCoords();
+        String id = ArtifactCoords.of(nonPlatformExtensionCoords.getGroupId(),
+                nonPlatformExtensionCoords.getArtifactId(),
+                quarkusVersion,
+                nonPlatformExtensionCoords.getType(),
+                nonPlatformExtensionCoords.getVersion()).toString();
+        return id;
     }
 
     private enum CoreCompatibility {

--- a/src/main/java/io/quarkus/registry/app/maven/MavenConfig.java
+++ b/src/main/java/io/quarkus/registry/app/maven/MavenConfig.java
@@ -49,8 +49,13 @@ public class MavenConfig {
                 Constants.DEFAULT_REGISTRY_ARTIFACT_VERSION);
     }
 
-    public ArtifactCoords getNonPlatformExtensionCoords() {
-        return nonPlatformExtensionCoords;
+    public String getNonPlatformExtensionCoords(String quarkusVersion) {
+        String id = ArtifactCoords.of(nonPlatformExtensionCoords.getGroupId(),
+                nonPlatformExtensionCoords.getArtifactId(),
+                quarkusVersion,
+                nonPlatformExtensionCoords.getType(),
+                nonPlatformExtensionCoords.getVersion()).toString();
+        return id;
     }
 
     public boolean supports(ArtifactCoords artifact) {
@@ -119,4 +124,5 @@ public class MavenConfig {
     public Optional<Boolean> getQuarkusVersionsExclusiveProvider() {
         return quarkusVersionsExclusiveProvider;
     }
+
 }

--- a/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
@@ -53,7 +53,7 @@ public class ExtensionRelease extends BaseEntity {
      * The version above formatted for max and order-by operations
      */
     @Column(updatable = false, length = 100)
-    private String versionSortable;
+    public String versionSortable;
 
     @Type(type = JsonTypes.JSON_BIN)
     @Column(columnDefinition = "json")

--- a/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
@@ -39,6 +39,14 @@ import io.quarkus.registry.app.util.Version;
                     )
             )
         """)
+
+@NamedQuery(name = "ExtensionRelease.findLatestExtensions", query = """
+            select ext from ExtensionRelease ext
+            where (ext.versionSortable) = (
+                select max(ext2.versionSortable) from ExtensionRelease ext2
+                where ext2.extension = ext.extension
+                )
+        """)
 public class ExtensionRelease extends BaseEntity {
 
     @NaturalId
@@ -116,6 +124,11 @@ public class ExtensionRelease extends BaseEntity {
                 .setParameter("upperBound", Version.toSortable(upperBound))
                 .setParameter("quarkusCore", quarkusCore)
                 .setParameter("quarkusCoreSortable", Version.toSortable(quarkusCore))
+                .getResultList();
+    }
+
+    public static List<ExtensionRelease> findLatestExtensions() {
+        return getEntityManager().createNamedQuery("ExtensionRelease.findLatestExtensions", ExtensionRelease.class)
                 .getResultList();
     }
 

--- a/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
@@ -61,7 +61,7 @@ public class ExtensionRelease extends BaseEntity {
      * The version above formatted for max and order-by operations
      */
     @Column(updatable = false, length = 100)
-    public String versionSortable;
+    private String versionSortable;
 
     @Type(type = JsonTypes.JSON_BIN)
     @Column(columnDefinition = "json")

--- a/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
+++ b/src/test/java/io/quarkus/registry/app/DatabaseRegistryClientTest.java
@@ -106,11 +106,26 @@ class DatabaseRegistryClientTest {
                 newExtension.groupId = "foo.bar";
                 newExtension.artifactId = "bar-extension";
                 newExtension.persist();
+                // Add a few releases to exercise the sorting
+                {
+                    ExtensionRelease extensionRelease = new ExtensionRelease();
+                    extensionRelease.extension = newExtension;
+                    extensionRelease.version = "0.2.2";
+                    extensionRelease.quarkusCoreVersion = "3.0.0.Final";
+                    extensionRelease.persist();
+                }
                 {
                     ExtensionRelease extensionRelease = new ExtensionRelease();
                     extensionRelease.extension = newExtension;
                     extensionRelease.version = "0.4.2";
                     extensionRelease.quarkusCoreVersion = "3.0.0.Final";
+                    extensionRelease.persist();
+                }
+                {
+                    ExtensionRelease extensionRelease = new ExtensionRelease();
+                    extensionRelease.extension = newExtension;
+                    extensionRelease.version = "0.1.0";
+                    extensionRelease.quarkusCoreVersion = "1.0.0.Final";
                     extensionRelease.persist();
                 }
             }
@@ -201,23 +216,18 @@ class DatabaseRegistryClientTest {
                 .body("platform", nullValue())
                 .body("derivedFrom", nullValue()) // These values don't make sense when listing all extensions
                 .body("quarkusCoreValue", nullValue())
-                .body("extensions", hasSize(4))
-                .body("extensions[0].artifact", is("foo.bar:foo-extension::jar:1.0.0"))
-                .body("extensions[1].artifact", is("foo.bar:foo-extension::jar:1.1.0"))
-                .body("extensions[2].artifact", is("foo.bar:bar-extension::jar:0.4.2"))
-                .body("extensions[3].artifact", is("foo.bar:baz-extension::jar:0.6.7"))
+                .body("extensions", hasSize(3))
+                .body("extensions[0].artifact", is("foo.bar:foo-extension::jar:1.1.0"))
+                .body("extensions[1].artifact", is("foo.bar:bar-extension::jar:0.4.2"))
+                .body("extensions[2].artifact", is("foo.bar:baz-extension::jar:0.6.7"))
                 // Now lets look at the reported platform information and make sure its accurate
-                .body("extensions[3].origins",
-                        // TODO we don't know what the member bom is
+                .body("extensions[2].origins",
                         is(List.of(
                                 "io.quarkus.platform:quarkus-bom-quarkus-platform-descriptor:2.1.0.Final:json:2.1.0.Final")))
-                .body("extensions[2].origins",
-                        is(List.of("io.quarkus.registry:quarkus-non-platform-extensions:3.0.0.Final:json:1.0-SNAPSHOT")))
                 .body("extensions[1].origins",
-                        is(List.of("io.quarkus.registry:quarkus-non-platform-extensions:2.1.0.Final:json:1.0-SNAPSHOT")))
+                        is(List.of("io.quarkus.registry:quarkus-non-platform-extensions:3.0.0.Final:json:1.0-SNAPSHOT")))
                 .body("extensions[0].origins",
-                        is(List.of("io.quarkus.registry:quarkus-non-platform-extensions:2.0.0.Final:json:1.0-SNAPSHOT")));
-
+                        is(List.of("io.quarkus.registry:quarkus-non-platform-extensions:2.1.0.Final:json:1.0-SNAPSHOT")));
     }
 
     @Test


### PR DESCRIPTION
It is sometimes useful to get a list of all of the known extensions, both platform and platform. At the moment, it is only easily possible to get the non-platform-extensions, and then only for a given Quarkus release. 

This PR adds a new endpoint, `/extensions/all`, which returns all of the extensions in the registry. 

There's some overlap in intention with #91 and #92, although the implementation here is much simpler and doesn't involve any schema changes. I don't totally know how the changes here relate to #92 (I only discovered it when submitting this PR). 

Because I didn't want to change the schema, there are a few aspects of the behaviour that are maybe not-perfect:

- Where multiple releases of an extension exist, each release gets its own entry in the json, without grouping. I decided consumer code could group if it cared. 
- I eventually want to be able to to look at an extension and find out what platforms its part of. We have that information in the database, but what’s in the OpenAPI schema is a bit more limited. What I did was take the information I had and populate a logical-seeming place in the Extension schema, `origins`.

It would be useful to know if 
- What I put in the `origins` field is sufficient to work backwards to a platform. If it's not, I will need to change the schema after all or find another approach. All that's in the json right now is the `id` of the `ExtensionOrigin`, not any of the other information. (I can see consuming code will have to do some heavy lift to figure out what the platform is from just the id.)
- What I put in the origins field is actually correct. :)  I had to guess how to go from a `PlatformRelease` to an `ExtensionOrigin`, and what the contents of the `id` field should be.
 
If we think these changes are ok, it might eventually make sense to add some other endpoints, such as `/extensions/non-platform/all` or `/extensions/non-platform?v=2.7.0`, just so that `extensions/all` isn't the only, lonely, `extensions` endpoint. But we can maybe YAGNI that.  

@gastaldi and/or @aloubyansky , what do you think?