### PR TITLE
Add some indexes to extension_release* tables

### DIFF
--- a/src/main/resources/db/migration/V14__Add_indexes_to_extension_tables.sql
+++ b/src/main/resources/db/migration/V14__Add_indexes_to_extension_tables.sql
@@ -1,0 +1,8 @@
+create index idx_extension_release_version_sortable on extension_release(version_sortable);
+create index idx_extension_release_quarkus_core_version on extension_release(quarkus_core_version);
+create index idx_extension_release_version on extension_release(version);
+create index idx_extension_release_extension_id on extension_release(extension_id);
+create index idx_extension_release_quarkus_core_version_sortable on extension_release(quarkus_core_version_sortable);
+
+create index idx_extension_release_compatibility_quarkus_core_version on extension_release_compatibility(quarkus_core_version);
+create index idx_extension_release_compatibility_extension_release_id on extension_release_compatibility(extension_release_id);


### PR DESCRIPTION
@gastaldi could we try to deploy that and see how it goes? It might be a good first step towards trying to improve the situation.

What would help further would be to get a dump of the production database and set a `log_min_duration_statement` to 1s there to get some input.