### PR TITLE
Fix version order when comparing SPs against Finals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,10 @@
       <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.smallrye.common</groupId>
+      <artifactId>smallrye-common-version</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkiverse.loggingsentry</groupId>
       <artifactId>quarkus-logging-sentry</artifactId>
       <version>${quarkus-logging-sentry.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     <dependency>
       <groupId>io.smallrye.common</groupId>
       <artifactId>smallrye-common-version</artifactId>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.loggingsentry</groupId>

--- a/src/main/java/io/quarkus/registry/app/util/Version.java
+++ b/src/main/java/io/quarkus/registry/app/util/Version.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
+import io.smallrye.common.version.VersionScheme;
+
 public class Version {
 
     /**
@@ -36,16 +38,16 @@ public class Version {
             if (!isQualifierPreFinal(rightQualifier)) {
                 result = 1;
             } else {
-                result = leftVersion.compareTo(rightVersion);
+                result = VersionScheme.MAVEN.compare(left, right);
             }
         } else if (isQualifierPreFinal(rightQualifier)) {
             if (!isQualifierPreFinal(leftQualifier)) {
                 result = -1;
             } else {
-                result = rightVersion.compareTo(leftVersion);
+                result = VersionScheme.MAVEN.compare(right, left);
             }
         } else {
-            result = rightVersion.compareTo(leftVersion);
+            result = VersionScheme.MAVEN.compare(right, left);
         }
         return result;
     });

--- a/src/test/java/io/quarkus/registry/app/util/VersionTest.java
+++ b/src/test/java/io/quarkus/registry/app/util/VersionTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class VersionTest {
@@ -54,7 +53,6 @@ class VersionTest {
     }
 
     @Test
-    @Disabled("See https://issues.apache.org/jira/browse/MNG-7690")
     void sortSPs() {
         List<String> versions = Arrays.asList(
                 "2.13.7.Final-redhat-00003",


### PR DESCRIPTION
- Requires a released smallrye-common-version with the fix in https://github.com/smallrye/smallrye-common/pull/212
