### PR TITLE
Update extension release compatibility lookup

### DIFF
--- a/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionRelease.java
@@ -45,7 +45,7 @@ import io.quarkus.registry.app.util.Version;
                 extension_release
                 JOIN extension ON extension.id = extension_release.extension_id
                 LEFT JOIN platform_extension ON extension_release.id = platform_extension.extension_release_id
-                LEFT JOIN extension_release_compatibility ON extension_release_compatibility.extension_release_id = extension_release.id AND extension_release_compatibility.quarkus_core_version = :quarkusCore
+                LEFT JOIN extension_release_compatibility ON extension_release_compatibility.extension_release_id = extension_release.id AND :quarkusCore like extension_release_compatibility.quarkus_core_version
             WHERE
                 platform_extension.id IS NULL AND (
                     (extension_release.quarkus_core_version_sortable <= :quarkusCoreSortable AND

--- a/src/main/java/io/quarkus/registry/app/model/ExtensionReleaseCompatibility.java
+++ b/src/main/java/io/quarkus/registry/app/model/ExtensionReleaseCompatibility.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.NaturalId;
 @Entity
 @NamedQuery(name = "ExtensionReleaseCompatibility.findCompatibility", query = """
         select e.extensionRelease.id as id, e.compatible as compatible from ExtensionReleaseCompatibility e
-        where e.quarkusCoreVersion = :quarkusCore
+        where :quarkusCore like e.quarkusCoreVersion
         """)
 public class ExtensionReleaseCompatibility extends BaseEntity {
 


### PR DESCRIPTION
- Change the query for finding extension release compatibility to use `like` instead of `=`
- Update the `extension_release_compatibility` join condition to use a `like` match
- Related to #128
