### PR TITLE
Improve error handling and validation for Maven resources

### DIFF
--- a/src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java
+++ b/src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java
@@ -47,7 +47,7 @@ public class PlatformsContentProvider implements ArtifactContentProvider {
             platformCatalog = registryClient.resolveCurrentPlatformsCatalog(quarkusVersion);
         }
         if (platformCatalog == null || platformCatalog.getPlatforms().isEmpty()) {
-            return Response.status(Response.Status.NO_CONTENT)
+            return Response.status(Response.Status.NOT_FOUND)
                     .header("X-Reason", "No platforms found")
                     .build();
         }

--- a/src/main/java/io/quarkus/registry/app/util/Version.java
+++ b/src/main/java/io/quarkus/registry/app/util/Version.java
@@ -18,7 +18,7 @@ public class Version {
      */
     public static void validateVersion(String version) {
         DefaultArtifactVersion dav = new DefaultArtifactVersion(version);
-        if (dav.getMajorVersion() == 0) {
+        if (dav.getMajorVersion() == 0 && dav.getMinorVersion() == 0 && dav.getIncrementalVersion() == 0) {
             throw new IllegalArgumentException("Invalid Version: " + version);
         }
     }

--- a/src/test/java/io/quarkus/registry/app/services/MavenResourceTest.java
+++ b/src/test/java/io/quarkus/registry/app/services/MavenResourceTest.java
@@ -133,15 +133,6 @@ public class MavenResourceTest extends BaseTest {
     }
 
     @Test
-    void should_return_204_on_inexistent_platforms() {
-        given()
-                .get("/maven/io/quarkus/registry/quarkus-platforms/1.0-SNAPSHOT/quarkus-platforms-1.0-SNAPSHOT-10.1.0.CR1.json")
-                .then()
-                .statusCode(204)
-                .header("X-Reason", "No platforms found");
-    }
-
-    @Test
     void non_platform_descriptor_should_contain_quarkus_core() {
         given()
                 .get("/maven/io/quarkus/registry/quarkus-non-platform-extensions/1.0-SNAPSHOT/quarkus-non-platform-extensions-1.0-SNAPSHOT-2.1.3.Final.json")
@@ -152,10 +143,34 @@ public class MavenResourceTest extends BaseTest {
     }
 
     @Test
-    void should_return_bad_request_if_version_is_invalid() {
+    void should_return_not_found_if_version_is_invalid() {
         given()
                 .get("/maven/io/quarkus/registry/quarkus-platforms/1.0-SNAPSHOT/quarkus-platforms-1.0-SNAPSHOT-0.23.2.json")
                 .then()
-                .statusCode(HttpURLConnection.HTTP_BAD_REQUEST);
+                .statusCode(HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+    @Test
+    void should_return_not_found_if_snapshot_version_is_invalid() {
+        given()
+                .get("/maven/io/quarkus/registry/quarkus-platforms/1.0-SNAPSHOT/quarkus-platforms-1.0-SNAPSHOT-999-SNAPSHOT.json")
+                .then()
+                .statusCode(HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+    @Test
+    void should_return_not_found_to_sha1_if_version_is_invalid() {
+        given()
+                .get("/maven/io/quarkus/registry/quarkus-platforms/1.0-SNAPSHOT/quarkus-platforms-1.0-SNAPSHOT-0.23.2.json.sha1")
+                .then()
+                .statusCode(HttpURLConnection.HTTP_NOT_FOUND);
+    }
+
+    @Test
+    void should_return_not_found_to_sha1_if_snapshot_version_is_invalid() {
+        given()
+                .get("/maven/io/quarkus/registry/quarkus-platforms/1.0-SNAPSHOT/quarkus-platforms-1.0-SNAPSHOT-999-SNAPSHOT.sha1")
+                .then()
+                .statusCode(HttpURLConnection.HTTP_NOT_FOUND);
     }
 }


### PR DESCRIPTION
- Update status codes for invalid requests
- Remove test for inexistent platforms
- Update test for platforms
- Require all version numbers to be larger than 0 for validation
- Fixes #183
- Fixes https://github.com/quarkusio/quarkus/issues/32266

[src/test/java/io/quarkus/registry/app/services/MavenResourceTest.java]
- Change return status code from `400` to `404` for requests with invalid version
- Change return status code from `400` to `404` for requests with invalid snapshot version
- Change return status code from `400` to `404` for requests with invalid version in sha1 file
- Change return status code from `400` to `404` for requests with invalid snapshot version in sha1 file
- Remove test for inexistent platforms
- Update test for
[src/main/java/io/quarkus/registry/app/maven/PlatformsContentProvider.java]
- Change the response status from `NO_CONTENT` to `NOT_FOUND` when no platforms are found
[src/main/java/io/quarkus/registry/app/util/Version.java]
- Require major, minor, and incremental versions to be larger than 0 for validation
